### PR TITLE
Dotenv support

### DIFF
--- a/blitz/settings.py
+++ b/blitz/settings.py
@@ -4,7 +4,7 @@ import os
 
 from pydantic_settings import BaseSettings
 
-DOTENV = os.path.join(os.path.dirname(__file__), ".env")
+DOTENV = os.path.join(os.getcwd(), ".env")
 
 
 class DBTypes(enum.StrEnum):


### PR DESCRIPTION
Only change the way we import the `dotenv` file.
Before we used `Path(__file__) ` so the dotenv had to be next to the `settings.py`

Now, we use `os.getcwd()` to use the current working directory.

Maybe in the future iteration we should search for a `.env` file in the blitz app folder, because we maybe have specific port for specific apps.

What do you think ?