### PR TITLE
Feature/doc quickstart

### DIFF
--- a/blitz/cli/app.py
+++ b/blitz/cli/app.py
@@ -1,7 +1,7 @@
-# from .commands.swagger import list_routes
 import typer
 
 from blitz.cli.commands.clone import clone_project
+from blitz.cli.commands.callback import callback
 
 from .commands.create import create_blitz_app
 from .commands.list import list_blitz_app
@@ -9,12 +9,13 @@ from .commands.release import release_blitz
 from .commands.start import start_blitz
 from .commands.swagger import list_routes
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 app.command(name="create")(create_blitz_app)
 app.command(name="list")(list_blitz_app)
 app.command(name="start")(start_blitz)
 app.command(name="release")(release_blitz)
 app.command(name="swagger")(list_routes)
 app.command(name="clone")(clone_project)
+app.callback(invoke_without_command=True)(callback)
 # dev only
 # app.command(name="clean")(clean_blitz)

--- a/blitz/cli/commands/callback.py
+++ b/blitz/cli/commands/callback.py
@@ -1,0 +1,11 @@
+from typing import Annotated, Optional
+import typer
+from blitz import __version__
+
+def version_callback(show_version: bool) -> None:
+    if show_version:
+        print(__version__)
+
+def callback(version: Annotated[Optional[bool], typer.Option("--version", help="Show the Blitz version.", callback=version_callback)] = None) -> None:
+    if version:
+        print(__version__)

--- a/blitz/cli/commands/clone.py
+++ b/blitz/cli/commands/clone.py
@@ -5,7 +5,7 @@ import requests
 import typer
 from blitz.cli.commands.create import BlitzProjectCreator
 from blitz.cli.utils import progress
-from blitz.models.blitz.file import BlitzFile
+from blitz.models.blitz.file import BlitzFile, InvalidFileTypeError
 
 
 def clone_project(
@@ -25,6 +25,9 @@ def clone_project(
             blitz_file = BlitzFile.from_url(url, name, format=format)
         except (requests.HTTPError, JSONDecodeError):
             print(f"Failed to clone the project from {url}")
+            raise typer.Exit(1)
+        except InvalidFileTypeError as err:
+            print(err)
             raise typer.Exit(1)
 
     name = name or blitz_file.config.name

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,2 +1,143 @@
-!!! warning
-    **WORK IN PROGRESS**
+# API
+
+The Blitz API contains all the exposed CRUD operations defined on the [Blitz File](/blitz/blitzfile/), but also the `/blitz-file` which is, as its name suggests, the Json representation of the running Blitz File.
+
+This feature is used for the [clone command](/blitz/cli/clone/) and the [--url option of the start command](/blitz/cli/start).
+
+This feature can be disabled with the `--no-config-route` option of the start command.
+
+For exemple, this is the return of the demo `/blitz-file`:
+
+```json
+{
+    "config":{
+        "name":"Demo Blitz App",
+        "description":"This is a demo blitz app",
+        "version":"0.1.0"
+    },
+    "resources":{
+        "Food":{
+            "name":{
+                "type":"str",
+                "nullable":false,
+                "unique":true
+            },
+            "expiration_date":{
+                "type":"datetime",
+                "nullable":false,
+                "unique":false
+            }
+        },
+        "Ingredient":{
+            "food_id":{
+                "type":"uuid",
+                "foreign_key":"Food.id",
+                "nullable":true,
+                "unique":false
+            },
+            "food":{
+                "type":"relationship",
+                "relationship":"Food",
+                "relationship_list":false,
+                "nullable":false,
+                "unique":false
+            },
+            "recipe_id":{
+                "type":"uuid",
+                "foreign_key":"Recipe.id",
+                "nullable":true,
+                "unique":false
+            },
+            "recipe":{
+                "type":"relationship",
+                "relationship":"Recipe",
+                "relationship_list":false,
+                "nullable":false,
+                "unique":false
+            }
+        },
+        "Recipe":{
+            "name":{
+                "type":"str",
+                "nullable":false,
+                "unique":true
+            },
+            "ingredients":{
+                "type":"relationship",
+                "relationship":"Ingredient",
+                "relationship_list":true,
+                "nullable":false,
+                "unique":false
+            },
+            "cook_id":{
+                "type":"uuid",
+                "foreign_key":"Cook.id",
+                "nullable":true,
+                "unique":false
+            },
+            "cook":{
+                "type":"relationship",
+                "relationship":"Cook",
+                "relationship_list":false,
+                "nullable":false,
+                "unique":false
+            }
+        },
+        "Cook":{
+            "name":{
+                "type":"str",
+                "nullable":false,
+                "unique":true
+            },
+            "age":{
+                "type":"int",
+                "nullable":false,
+                "unique":false
+            },
+            "recipes":{
+                "type":"relationship",
+                "relationship":"Recipe",
+                "relationship_list":true,
+                "nullable":false,
+                "unique":false
+            },
+            "rat":{
+                "type":"relationship",
+                "relationship":"Rat",
+                "relationship_list":false,
+                "nullable":false,
+                "unique":false
+            }
+        },
+        "Rat":{
+            "name":{
+                "type":"str",
+                "nullable":false,
+                "unique":true
+            },
+            "age":{
+                "type":"int",
+                "nullable":false,
+                "unique":false
+            },
+            "cook_id":{
+                "type":"uuid",
+                "foreign_key":"Cook.id",
+                "nullable":true,
+                "unique":true
+            },
+            "cook":{
+                "type":"relationship",
+                "relationship":"Cook",
+                "relationship_list":false,
+                "nullable":false,
+                "unique":false
+            }
+        }
+    }
+}
+```
+
+!!! tip "Want to master the syntax of Blitz?"
+
+    You can **[learn here](/blitz/blitzfile/)** how the Blitz File work.

--- a/docs/cli/clone.md
+++ b/docs/cli/clone.md
@@ -1,0 +1,27 @@
+# Clone
+
+With clone you can create a new Blitz project from a Blitz App running on a remote server.
+
+A Blitz App can expose the `/blitz-file` endpoint which is the Blitz file of the current running Blitz App.
+
+!!! tip
+    You can desactivate this feature with  `blitz start --no-config-route` option.
+
+You can try it with the demo:
+```console
+blitz clone https://demo.blitz.paperz.app/blitz-file
+```
+
+<!-- termynal -->
+
+<div class="termy">
+
+```console
+$ blitz clone https://demo.blitz.paperz.app/blitz-file
+
+<span style="color: #af87ff; font-weight: bold;">Demo Blitz App</span> created successfully !
+To start your app, you can use:
+    <span style="color: #af87ff; font-weight: bold;">blitz start demo-blitz-app</span>
+```
+
+</div>

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -1,4 +1,4 @@
-The `blitz start` command is used to start an existing blitz app. It will start the blitz API, the blitz admin and the blitz UI.
+The `blitz start` command is used to start an existing Blitz App. It will start the Blitz API, the blitz admin and the blitz UI.
 
 <!-- termynal -->
 
@@ -24,3 +24,15 @@ $ blitz start your-blitz-app
 
 !!! note
     Use `blitz create --help` to see all available options.
+
+## --url
+
+With the `--url` option, you can start a Blitz App directly from a remote server Blitz File exposed on the `/blitz-file` route.
+
+You can try it with the demo:
+```console
+blitz start --url https://demo.blitz.paperz.app/blitz-file
+```
+
+!!! tips
+    You can clone the project locally with the [clone command](/blitz/cli/clone/)

--- a/docs/dashboard/admin.md
+++ b/docs/dashboard/admin.md
@@ -1,0 +1,5 @@
+# Admin
+The admin is provided by [Starlette Admin](https://github.com/jowilf/starlette-admin)
+
+Check the [admin from the Live Demo](https://demo.blitz.paperz.app/admin/).
+

--- a/docs/dashboard/blitz_file.md
+++ b/docs/dashboard/blitz_file.md
@@ -1,0 +1,6 @@
+# Blitz File Editor
+
+The Dashboard has a Blitz file editor (only JSON for now) to directly create or update your resources.
+
+You can test our [Blitz file editor in the Live Demo](https://demo.blitz.paperz.app/dashboard/projects/demo-blitz-app/blitz-file).
+

--- a/docs/dashboard/diagram.md
+++ b/docs/dashboard/diagram.md
@@ -1,0 +1,3 @@
+# Diagram
+
+The demo diagram is [available here](https://demo.blitz.paperz.app/dashboard/projects/demo-blitz-app/diagram).

--- a/docs/dashboard/gpt_builder.md
+++ b/docs/dashboard/gpt_builder.md
@@ -1,0 +1,17 @@
+# GPT Builder
+
+You can chat with GPT to create or improve Blitz file.
+
+You have to set an OpenAI API Key in the settings (or as environment variable for local projects).
+
+We will automaticly detect valid Blitz File and you will be able to copy to clipboard or download in yaml or Json.
+
+You can [chat with our builder in the Live Demo](https://demo.blitz.paperz.app/dashboard/gpt).
+
+Features:
+
+- Detect valid and invalid Blitz files.
+- Change or update the pre-prompt, to provide your context and your needs to GPT.
+- Choose between GPT 3.5 turbo and GPT 4.
+
+

--- a/docs/dashboard/index.md
+++ b/docs/dashboard/index.md
@@ -1,1 +1,18 @@
-Blitz has a dashboard and an admin.
+# Overview
+Blitz has a native dashboard and an admin.
+
+You can test it in our [Live Demo](https://demo.blitz.paperz.app)
+
+# Main features
+- **Swagger UI**: You can interect with the swagger ui directly in the Blitz Dashboard.
+- **Blitz File Editor**: The dashboard provides users with direct access to the Blitz file, allowing them to make instantaneous modifications as needed.
+- **Panel Admin Data Management**: Interface for managing database resources, ensuring efficient organization, manipulation, and retrieval of data
+- **Dynamic Blitz File Generation**: Utilizing GPT capabilities, users can prompt the system to generate new Blitz files on demand, streamlining the process of creating and updating Blitz files.
+- **Mermaid Diagram Visualization**
+- **Log Visualization**.
+
+   
+
+    
+
+    

--- a/docs/dashboard/index.md
+++ b/docs/dashboard/index.md
@@ -1,0 +1,1 @@
+Blitz has a dashboard and an admin.

--- a/docs/dashboard/logs.md
+++ b/docs/dashboard/logs.md
@@ -1,0 +1,7 @@
+# Logs
+
+The log page of the dashboard is always in WIP.
+
+The [demo version](https://demo.blitz.paperz.app/dashboard/projects/demo-blitz-app/logs) is anonymised.
+
+Run the [blitz demo locally](/blitz/) to see more.

--- a/docs/dashboard/swagger.md
+++ b/docs/dashboard/swagger.md
@@ -1,0 +1,6 @@
+# Swagger
+
+You can interact with the swagger directly inside the Blitz Dashboard.
+
+You can play with the [Swagger from the Live Demo](https://demo.blitz.paperz.app/dashboard/projects/demo-blitz-app/swagger).
+

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,6 @@ Get a swagger UI for all you routes with automatic documentation.
 
 Internally manages database schema and generates data migration to keep your database up to date with your Blitz file.
 
-## Dashboard
+## Dashboard & Admin
 
 Use the intuitive dashboard to build your Blitz app, manage your data and test your API.

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,10 @@ To start your app, you can use:
 
 *And yeah, that's it.*
 
+!!! tip "Want to master Blitz?"
+
+    You can **[learn here](/blitz/blitzfile/)** how to create resources.
+    
 Just add some resources in the blitz file, and you now have a fully functional API and the corresponding database schema, along with all the modern features you can expect from a modern app like:
 
 - **Automatic Swagger UI** for the API

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,27 +55,90 @@ Here is an example of how simple a Blitz file is:
       }
     }
     ```
-
-Just run:
-
+# Installation
+### Using [pipx](https://pipx.pypa.io/stable/installation/) (recommanded)
+```bash
+pipx install git+https://github.com/Paperz-org/blitz.git@v0.2.0
 ```
-blitz start your-blitz-project
+# Quickstart
+## Create a demo blitz app
+
+```console
+blitz create --demo
 ```
+<!-- termynal -->
 
-_And yeah, that's it._
+<div class="termy">
+```console
+$ blitz create --demo
 
-!!! note
+<span style="color: #af87ff; font-weight: bold;">Demo Blitz App</span> created successfully !
+To start your app, you can use:
+    <span style="color: #af87ff; font-weight: bold;">blitz start demo-blitz-app</span>
+```
+</div>
 
-    Assuming a `your-blitz-project` directory created using the blitz create command
+## Start the demo
+```console
+blitz start
+```
+<!-- termynal -->
+<div class="termy">
+```console
+$ blitz start
 
----
+<span style="color: yellow; font-weight: bold;">This is still an alpha. Please do not use in production.</span>
+<span style="color: yellow; font-weight: bold;">Please report any issues on https://github.com/Paperz-org/blitz</span>
 
-You have now a fully functional API with two resources and the corresponding database schema with all the modern feature you can expect from a modern app like:
+<span style="color: #af87ff; font-weight: bold;">Blitz app deployed.</span>
+<span style="color: #af87ff; font-weight: bold;">  - Blitz UI            : <a style="cursor: pointer" href="http://0.0.0.0:8100" target="_blank" rel="noopener noreferrer">http://0.0.0.0:8100</a></span>
+<span style="color: #af87ff; font-weight: bold;">  - Blitz admin         : <a style="cursor: pointer" href="http://0.0.0.0:8100/admin" target="_blank" rel="noopener noreferrer">http://0.0.0.0:8100/admin</a></span>
+<span style="color: #af87ff; font-weight: bold;">  - Swagger UI          : <a style="cursor: pointer" href="http://0.0.0.0:8100/api/docs" target="_blank" rel="noopener noreferrer">http://0.0.0.0:8100/api/docs</a></span>
 
-- Automatic Swagger UI for the API
-- Data validation and error messages (thanks to [Fastapi](https://fastapi.tiangolo.com/) and [SQLModel](https://sqlmodel.tiangolo.com/))
-- Automatic database migration based on the changes of your blitz file
-- Generated ERD diagram
-- Dashboard
-- Admin
+<span style="color: lightblue; font-weight: bold;">INFO</span>      random-blitz-app Started server process [21292026]
+<span style="color: lightblue; font-weight: bold;">INFO</span>      random-blitz-app Waiting for application startup.
+<span style="color: lightblue; font-weight: bold;">INFO</span>      random-blitz-app Application startup complete.
+```
+</div>
+
+## Enjoy the demo
+
+The blitz demo already includes resources to explore all the functionalities of Blitz.
+You can see the Dashboard of the demo blitz app in our [Live Demo](https://demo.blitz.paperz.app/).
+
+## Create a blitz app
+
+```console
+blitz create
+```
+<!-- termynal -->
+
+<div class="termy">
+```console
+$ blitz create
+Enter the name of your blitz app (Random Blitz App):
+// My First App
+Enter the description of your blitz app ():
+// this is my first blitz app
+Choose the format of the blitz file [json/yaml] (yaml):
+// yaml
+
+<span style="color: #af87ff; font-weight: bold;">My First App</span> created successfully !
+To start your app, you can use:
+    <span style="color: #af87ff; font-weight: bold;">blitz start my-first-app</span>
+```
+</div>
+
+*And yeah, that's it.*
+
+Just add some resources in the blitz file, and you now have a fully functional API and the corresponding database schema, along with all the modern features you can expect from a modern app like:
+
+- **Automatic Swagger UI** for the API
+- **Admin Interface**
+- **Dashboard**: including GPT builder, Blitz file editor, logs ...
+- **Data Validation and Error Messages** (thanks to Fastapi and SQLModel)
+- **Automatic Database Migration**
+- **Generated ERD Diagram**
 - and more...
+
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,5 +2,5 @@
 
 ## Using [pipx](https://pipx.pypa.io/stable/installation/) (recommanded)
 ```bash
-pipx install git+https://github.com/Paperz-org/blitz.git@v0.1.0
+pipx install git+https://github.com/Paperz-org/blitz.git@v0.2.0
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,0 @@
-First of all, have a look on the [Installation](installation.md) page to install Blitz. Once Blitz is installed, you can start to create your first Blitz project using the Blitz CLI.
-
-```bash
-blitz create --demo
-blitz start demo-blitz-app
-```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
           - Start: cli/start.md
           - List: cli/list.md
           - Release: cli/release.md
+          - Clone: cli/clone.md
       - References: cli/references.md
   - API:
       - Blitz API: api/index.md
@@ -105,6 +106,7 @@ nav:
       - Admin: dashboard/admin.md
       - Swagger: dashboard/swagger.md
       - Blitz File Editor: dashboard/blitz_file.md
+      - GPT Builder: dashboard/gpt_builder.md
       - Diagram: dashboard/diagram.md
       - Logs: dashboard/logs.md
-      - GPT Builder: dashboard/gpt_builder.md
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,6 @@ nav:
       - Welcome to Blitz: index.md
       - Features: features.md
       - Installation: installation.md
-      - Quickstart: quickstart.md
   - Blitz file:
       - Overview: blitzfile/index.md
       - Config: blitzfile/config.md
@@ -93,7 +92,6 @@ nav:
       - Relationships: blitzfile/relationships.md
       - Blitz file reference: blitzfile/reference.md
   - CLI:
-      - Installation: cli/index.md
       - Commands:
           - Create: cli/create.md
           - Start: cli/start.md
@@ -103,4 +101,10 @@ nav:
   - API:
       - Blitz API: api/index.md
   - Dashboard:
-      - Dashboard: dashboard.md
+      - Overview: dashboard/index.md
+      - Admin: dashboard/admin.md
+      - Swagger: dashboard/swagger.md
+      - Blitz File Editor: dashboard/blitz_file.md
+      - Diagram: dashboard/diagram.md
+      - Logs: dashboard/logs.md
+      - GPT Builder: dashboard/gpt_builder.md


### PR DESCRIPTION
- Complete v0.2.0 documentation
- Create the --version option: `blitz --version` show the current version of blitz.
- Fix the output of the --demo option in case of non allowed file type.